### PR TITLE
SWF-4325 : Add Maven OWASP Dependency Check plugin to check dependencies vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
     <version.wikbook.plugin>0.9.45</version.wikbook.plugin>
     <version.xml.plugin>1.0</version.xml.plugin>
     <version.yuicompressor.plugin>0.7.1</version.yuicompressor.plugin>
+    <version.owasp.dependency-check-maven.plugin>3.1.2</version.owasp.dependency-check-maven.plugin>
     <!-- *************** -->
     <!-- Others versions -->
     <!-- *************** -->
@@ -1105,6 +1106,19 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
         <version>${version.surefire.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>${version.owasp.dependency-check-maven.plugin}</version>
+        <reportSets>
+          <reportSet>
+            <id>aggregate</id>
+            <reports>
+              <report>aggregate</report>
+            </reports>
+          </reportSet>
+        </reportSets>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
Adds the Maven OWASP Dependency Check plugin to check dependencies vulnerabilities.

As a first step, I added the Maven OWASP Dependency Check plugin only when generating the Maven site of a project, so it generates a new section with the list of vulnerabilities of this project.
I did not add this check as blocker for the build since there are a lot of vulnerabilities to fix, so it would require a lot of work to make the build success. But it should be done in a second step, once the current vulnerabilities are fixed.
@vsellier WDYT ?