### PR TITLE
SWF-4388 - Add test coverage ratio check in coverage profile, with a minimum ratio of 100%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,9 @@
     <!-- JUnit : org.sonar.java.jacoco.JUnitListener -->
     <!-- TestNG : org.sonar.java.jacoco.TestNGListener -->
     <jacoco.listener>org.sonar.java.jacoco.JUnitListener</jacoco.listener>
+    <!-- Minimal test coverage ratio to reach to make the build pass (from 0.0 to 1.0)
+         We intentionally set it to 100% by default to force all projects to define their own ratio -->
+    <exo.test.coverage.ratio>1.0</exo.test.coverage.ratio>
   </properties>
   <build>
     <extensions>
@@ -1464,6 +1467,54 @@
                 <configuration>
                   <destFile>${sonar.jacoco.itReportPath}</destFile>
                   <append>true</append>
+                </configuration>
+              </execution>
+              <execution>
+                <id>check-coverage</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <rule implementation="org.jacoco.maven.RuleConfiguration">
+                      <element>BUNDLE</element>
+                      <limits>
+                        <limit implementation="org.jacoco.report.check.Limit">
+                          <counter>INSTRUCTION</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>${exo.test.coverage.ratio}</minimum>
+                        </limit>
+                      </limits>
+                    </rule>
+                  </rules>
+                </configuration>
+              </execution>
+              <!-- Ensures that the code coverage report for unit tests is created after unit tests have been run. -->
+              <execution>
+                <id>post-unit-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <configuration>
+                  <!-- Sets the path to the file which contains the execution data. -->
+                  <dataFile>${sonar.jacoco.reportPath}</dataFile>
+                  <!-- Sets the output directory for the code coverage report. -->
+                  <outputDirectory>${project.reporting.outputDirectory}/test-coverage-ut</outputDirectory>
+                </configuration>
+              </execution>
+              <!-- Ensures that the code coverage report for integration tests after integration tests have been run. -->
+              <execution>
+                <id>post-integration-test</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <configuration>
+                  <!-- Sets the path to the file which contains the execution data. -->
+                  <dataFile>${sonar.jacoco.itReportPath}</dataFile>
+                  <!-- Sets the output directory for the code coverage report. -->
+                  <outputDirectory>${project.reporting.outputDirectory}/test-coverage-it</outputDirectory>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
This PR adds a build phase in the coverage profile to check if a minimum test coverage ratio is reached. It makes the build fail if not.

The goal is to improve our test coverage by starting to make sure it does not decrease and encouraging to increase it.

The default ratio is set to 100% to force modules to define their own ratio.
The rules about the update of this ratio are:
* it can NEVER be decreased
* when a developer increase the test coverage, he CAN (but this is recommended) increase the ratio
* ratio must always be defined with a 2 digits precision (for example 0.64)

Example of build failure because of the test coverage check:

```shell
[INFO] --- jacoco-maven-plugin:0.7.6.201602180812:check (check-coverage) @ commons-component-common ---
[INFO] Analyzed bundle 'eXo PLF:: Commons - Common Services' with 252 classes
[WARNING] Rule violated for bundle eXo PLF:: Commons - Common Services: instructions covered ratio is 0.48, but expected minimum is 0.80
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:22 min
[INFO] Finished at: 2018-07-03T23:13:40+02:00
[INFO] Final Memory: 71M/1003M
[INFO] ------------------------------------------------------------------------
```
and when it passes:

```shell
[INFO] --- jacoco-maven-plugin:0.7.6.201602180812:check (check-coverage) @ commons-component-common ---
[INFO] Analyzed bundle 'eXo PLF:: Commons - Common Services' with 252 classes
[INFO] All coverage checks have been met.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:23 min
[INFO] Finished at: 2018-07-03T23:19:27+02:00
[INFO] Final Memory: 79M/1404M
[INFO] ------------------------------------------------------------------------
```

The solution simply adds the goal jacoco-maven-plugin:check in the build process and defines a variable "exo.test.coverage.ratio" which must be overridden in modules to define their own ratio (see https://github.com/exodev/commons/pull/229 as an example).

Notes:
* it is not possible to do a global check on a multi-modules maven project, the jacoco plugin does not support it, so the ratio must be defined in each module.

Questions:
* this check must be blocker for the build, so defining it in the coverage profile only is not sufficient since this profile is only used in Sonar builds. A possible solution is to activate the coverage profile in all CI builds (either by adding it in all jobs configuration, either by moving coverage stuff in exo-release profile). The drawback is that it increases the build time (for example for Commons project : without the coverage it takes 02:25 min, with the coverage it takes 03:57 min - for Social project : without the coverage it takes 11:07 min, with the coverage it takes 15:19 min), but only on the CI. WDYT ?